### PR TITLE
file_name_fix_for_compilation_err

### DIFF
--- a/grasp_path_planner/CMakeLists.txt
+++ b/grasp_path_planner/CMakeLists.txt
@@ -176,7 +176,7 @@ include_directories(
 # See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
 
 catkin_install_python(PROGRAMS
-  scripts/full_planner_node.py
+  scripts/fp_node.py
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 ## Mark executable scripts (Python etc.) for installation


### PR DESCRIPTION
- [x] Fix the file name _scripts/full_planner_node.py_ to _scripts/fp_node.py_ for grasp_planner/cmake_lists.txt